### PR TITLE
Closes #43 - tag cpu.total.iowait as utilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Additional collectors may be enabled; policies and configurations for those coll
 
 ## Release History
 
+### Version next
+
+* Tagged cpu.total.iowait as a utilization metric.
+
 ### Version 3.2.0
 
 * Adjusted build to use metricly-cli for validation

--- a/analyticConfigurations/metric_meta-linux.json
+++ b/analyticConfigurations/metric_meta-linux.json
@@ -265,6 +265,13 @@
         }
       }
     }, {
+      "match" : "cpu\\.total\\.iowait",
+      "properties" : {
+        "tags" : {
+          "utilization" : true
+        }
+      }
+    }, {
       "match" : "netuitive.linux.iostat.max_util_percentage",
       "properties" : {
         "tags" : {


### PR DESCRIPTION
Tagging iowait as a utilization metric for use in the boxplot report.