### PR TITLE
Enhancement/network bandwidth computed metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Additional collectors may be enabled; policies and configurations for those coll
 
 ## Release History
 
+### Version next
+
+* Added computed metrics for network bytes transmitted per NIC and total.
+
 ### Version 3.3.0
 
 * Tagged cpu.total.iowait as a utilization metric.

--- a/analyticConfigurations/ace-linux.json
+++ b/analyticConfigurations/ace-linux.json
@@ -54,6 +54,12 @@
         "correlation" : true
       }
     }, {
+      "match" : "netuitive.linux.network.total_byte_all_nics",
+      "properties" : {
+        "baseline" : true,
+        "correlation" : true
+      }
+    },{
       "match" : "netuitive.linux.diskspace\\.(.*)\\.byte_percentused",
       "properties" : {
         "baseline" : false,
@@ -64,7 +70,7 @@
       "properties" : {
         "baseline" : false,
         "correlation" : false
-      }    
+      }
     }, {
       "match" : "netuitive.linux.diskspace\\.avg_byte_percentused",
       "properties" : {
@@ -76,7 +82,7 @@
       "properties" : {
         "baseline" : true,
         "correlation" : true
-      }   
+      }
     }, {
       "match" : "netuitive.linux.iostat.max.util_percentage",
       "properties" : {

--- a/analyticConfigurations/computed_metric-linux.json
+++ b/analyticConfigurations/computed_metric-linux.json
@@ -68,6 +68,21 @@
         "fqn" : "netuitive.linux.network.${1}.errorspercent"
       }
     }, {
+      "match" : "netuitive.linux.network.total_byte",
+      "properties" : {
+        "expression" : "data['network.${1}.rx_byte'].actual + data['network.${1}.tx_byte'].actual",
+        "for" : "network.(.*).(rx_byte|tx_byte)",
+        "fqn" : "netuitive.linux.network.${1}.total_byte",
+        "name" : "Network Total Bytes Transmitted"
+      }
+    }, {
+      "match" : "netuitive.linux.network.total_byte_all_nics",
+      "properties" : {
+        "expression" : "data.sum('network\\..*\\.(rx_byte|tx_bye)')",
+        "fqn" : "netuitive.linux.network.total_byte_all_nics",
+        "name" : "Network Total Bytes Transmitted Across All NICs"
+      }
+    }, {
        "match":"netuitive.linux.diskspace.byte_percentused",
        "properties":{
          "expression":"100 - data['diskspace.${1}.byte_percentfree'].actual",

--- a/analyticConfigurations/metric_meta-linux.json
+++ b/analyticConfigurations/metric_meta-linux.json
@@ -186,7 +186,7 @@
           "unit" : "bytes"
         }
       }
-    }  {
+    }, {
       "match" : "iostat\\..*\\.io",
       "properties" : {
         "STATISTIC" : "sum"

--- a/analyticConfigurations/metric_meta-linux.json
+++ b/analyticConfigurations/metric_meta-linux.json
@@ -171,6 +171,22 @@
         "STATISTIC" : "sum"
       }
     }, {
+      "match" : "netuitive.linux.network\\..*\\.total_byte",
+      "properties" : {
+        "STATISTIC" : "sum",
+        "tags" : {
+          "unit" : "bytes"
+        }
+      }
+    }, {
+      "match" : "netuitive.linux.network.total_byte_all_nics",
+      "properties" : {
+        "STATISTIC" : "sum",
+        "tags" : {
+          "unit" : "bytes"
+        }
+      }
+    }  {
       "match" : "iostat\\..*\\.io",
       "properties" : {
         "STATISTIC" : "sum"


### PR DESCRIPTION
These metrics are intended to show the amount of bytes sent and received per network interface and in total across all network interfaces.