### PR TITLE
Better compute memory utilization for RHEL 7 systems

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 ## Release History
 
+### Version next
+
+* Better compute memory utilization for RHEL 7 systems.
+
 ### Version 3.8.0
 
 * Replace backslashes with square brackets for literals in computed metrics.

--- a/analyticConfigurations/computed_metric-linux.json
+++ b/analyticConfigurations/computed_metric-linux.json
@@ -5,6 +5,7 @@
         "match": "netuitive.linux.memory.utilizationpercent",
         "properties": {
           "expressions": [
+            "100 - 100 * (${memory.MemAvailable}.actual / ${memory.MemTotal}.actual)",
             "100 - 100 * (${memory.Buffers}.actual + ${memory.Cached}.actual + ${memory.MemFree}.actual) / ${memory.MemTotal}.actual"
           ],
           "fqn": "netuitive.linux.memory.utilizationpercent",


### PR DESCRIPTION
RHEL 7 introduced MemAvailable to /proc/meminfo: https://access.redhat.com/solutions/406773  

It's a better representation of memory available as it indicates how much is actually available for use by applications. This change is to first try computing the metric using MemAvailable as a substitute to the sum of MemFree, Buffers, and Cached. If the metric can't be computed with the first method, the original method is used. This way RHEL 6 and 7 systems are accounted for with the RHEL 7 method being the preferred one.

